### PR TITLE
Add typewriter flag loader

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,47 +4,40 @@ const FLAG_URL =
   "https://wgg522pwivhvi5gqsn675gth3q0otdja.lambda-url.us-east-1.on.aws/706174";
 
 export default function App() {
-  const [flag, setFlag] = useState("");
-  const [displayed, setDisplayed] = useState([]);
+  const [letters, setLetters] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [index, setIndex] = useState(0);
 
   useEffect(() => {
     fetch(FLAG_URL)
       .then((res) => res.text())
       .then((text) => {
-        const cleaned = text.replace(/<[^>]+>/g, "").trim();
-        setFlag(cleaned);
-        setLoading(false);
+        const cleaned = text.replace(/[^a-zA-Z]/g, "");
+        setLetters(cleaned.split(""));
       })
       .catch((err) => {
         console.error("Error fetching flag:", err);
-        setLoading(false);
-      });
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   useEffect(() => {
-    if (!loading && flag) {
-      let i = 0;
-      setDisplayed([]); // clear previous run
-      const interval = setInterval(() => {
-        setDisplayed((prev) => [...prev, flag[i]]);
-        i++;
-        if (i >= flag.length) clearInterval(interval);
-      }, 500);
+    if (!loading && index < letters.length) {
+      const timeout = setTimeout(() => setIndex(index + 1), 500);
+      return () => clearTimeout(timeout);
     }
-  }, [flag, loading]);
+  }, [loading, index, letters]);
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
 
   return (
-    <div>
-      {loading ? (
-        <p>Loading...</p>
-      ) : (
-        <ul>
-          {displayed.map((char, index) => (
-            <li key={index}>{char}</li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <ul>
+      {letters.slice(0, index).map((char, i) => (
+        <li key={i}>{char}</li>
+      ))}
+    </ul>
   );
 }
+


### PR DESCRIPTION
## Summary
- fetch flag text from provided endpoint and strip non-letter characters
- reveal flag letters sequentially with 500ms interval typewriter effect
- show a loading state while the flag is requested

## Testing
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688cdd31bb8c833280231e61f35c6fcf